### PR TITLE
SKY-1298 Use double splat to destructure hashed keyword args

### DIFF
--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -13,7 +13,7 @@ module DeadlockRetry
     MAXIMUM_RETRIES_ON_DEADLOCK = 3
 
 
-    def transaction(*objects, &block)
+    def transaction(**objects, &block)
       retry_count = 0
 
       check_innodb_status_available

--- a/lib/deadlock_retry/version.rb
+++ b/lib/deadlock_retry/version.rb
@@ -1,3 +1,3 @@
 module DeadlockRetry
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end


### PR DESCRIPTION
https://ujetcs.atlassian.net/browse/SKY-1298

Use double splat to convert hash into keywords arguments.
Reproduced locally and tested fix by modifying Gemfile to bugfix branch.
There is another instance of transaction using arguments  in
web/app/services/purchase/provider_braintree.rb.

This is similar to delete_extra_payloads usage of transaction. I tested the 
spec/services/purchase/provider_braintree_spec.rb as well.

TODO : After this fix is merged in master, I need to update version of deadlock_retry in ujet-server Gemfile.