### PR TITLE
SKY-1298 Use double splat to destructure hashed keyword args

### DIFF
--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -13,7 +13,7 @@ module DeadlockRetry
     MAXIMUM_RETRIES_ON_DEADLOCK = 3
 
 
-    def transaction(*objects, &block)
+    def transaction(**objects, &block)
       retry_count = 0
 
       check_innodb_status_available

--- a/lib/deadlock_retry/version.rb
+++ b/lib/deadlock_retry/version.rb
@@ -1,3 +1,3 @@
 module DeadlockRetry
-  VERSION = '1.2.2'
+  VERSION = '1.2.3'
 end


### PR DESCRIPTION
Tested in OEM env ujet-tmp-b1298
After merging this change, I'll create a new release/tag and modify Gemfile in ujet-server to use it.